### PR TITLE
Fix param name

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -9,7 +9,7 @@ override the default configuration with the following parameters:
 * `description` - A description about the deployment, optional
 * `auto_create` - Automatically create the application, defaults to `false`
 * `process` - Preprocess and validate the manifest, defaults to `false`
-* `bucket_name` - Bucket for `S3` source bundle
+* `bucket` - Bucket for `S3` source bundle
 * `bucket_key` - Key for `S3` source bundle
 * `environment_update` - Flag whether to update ElasticBeansTalk environment with the new version
 * `environment_name` - Environment Name (optional), if update_environment true
@@ -28,6 +28,6 @@ deploy:
     version_label: v1
     description: Deployed with DroneCI
     auto_create: true
-    bucket_name: my-bucket-name
+    bucket: my-bucket-name
     bucket_key: 970d28f4dd477bc184fbd10b376de753
 ```


### PR DESCRIPTION
The param ```bucket_name``` as been rename ```bucket``` cf. https://github.com/josmo/drone-elastic-beanstalk/blob/master/main.go#L31