### PR TITLE
Remove deprecated signed yaml verification

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
-	"os"
-	"fmt"
 )
 
 var build string
@@ -38,7 +39,6 @@ func main() {
 			Value:  "us-east-1",
 			EnvVar: "PLUGIN_REGION",
 		},
-
 		cli.StringFlag{
 			Name:   "bucket-key",
 			Usage:  "upload files from source folder",
@@ -79,11 +79,6 @@ func main() {
 			Usage:  "update the environment",
 			EnvVar: "PLUGIN_ENVIRONMENT_UPDATE",
 		},
-		cli.BoolTFlag{
-			Name:   "yaml-verified",
-			Usage:  "Ensure the yaml was signed",
-			EnvVar: "DRONE_YAML_VERIFIED",
-		},
 	}
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
@@ -103,7 +98,6 @@ func run(c *cli.Context) error {
 		Process:           c.Bool("process"),
 		EnvironmentUpdate: c.Bool("environment-update"),
 		Region:            c.String("region"),
-		YamlVerified:      c.BoolT("yaml-verified"),
 	}
 
 	return plugin.Exec()

--- a/plugin.go
+++ b/plugin.go
@@ -39,17 +39,16 @@ type Plugin struct {
 // Exec runs the plugin
 func (p *Plugin) Exec() error {
 	// create the client
-
 	conf := &aws.Config{
 		Region: aws.String(p.Region),
 	}
 
-	// Use key and secret if provided otherwise fall back to ec2 instance profile
 	if p.Key != "" && p.Secret != "" {
-		log.Info("AWS Key and/or Secret not provided")
-		log.Warning("Falling back to ec2 instance profile")
 		conf.Credentials = credentials.NewStaticCredentials(p.Key, p.Secret, "")
+	} else {
+		log.Warn("AWS Key and/or Secret not provided (falling back to ec2 instance profile)")
 	}
+
 	client := elasticbeanstalk.New(session.New(), conf)
 
 	log.WithFields(log.Fields{

--- a/plugin.go
+++ b/plugin.go
@@ -46,6 +46,8 @@ func (p *Plugin) Exec() error {
 
 	// Use key and secret if provided otherwise fall back to ec2 instance profile
 	if p.Key != "" && p.Secret != "" {
+		log.Info("AWS Key and/or Secret not provided")
+		log.Warning("Falling back to ec2 instance profile")
 		conf.Credentials = credentials.NewStaticCredentials(p.Key, p.Secret, "")
 	}
 	client := elasticbeanstalk.New(session.New(), conf)
@@ -78,7 +80,7 @@ func (p *Plugin) Exec() error {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,
-		}).Error("Problem create application")
+		}).Error("Problem creating application")
 		return err
 	}
 	if p.EnvironmentUpdate == true && err == nil {

--- a/plugin.go
+++ b/plugin.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"errors"
 	"fmt"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -24,8 +24,7 @@ type Plugin struct {
 	// ap-southeast-2
 	// ap-northeast-1
 	// sa-east-1
-	Region       string
-	YamlVerified bool
+	Region string
 
 	BucketKey         string
 	Application       string
@@ -48,10 +47,7 @@ func (p *Plugin) Exec() error {
 	// Use key and secret if provided otherwise fall back to ec2 instance profile
 	if p.Key != "" && p.Secret != "" {
 		conf.Credentials = credentials.NewStaticCredentials(p.Key, p.Secret, "")
-	} else if p.YamlVerified != true {
-		return errors.New("Security issue: When using instance role you must have the yaml verified")
 	}
-
 	client := elasticbeanstalk.New(session.New(), conf)
 
 	log.WithFields(log.Fields{


### PR DESCRIPTION
As of Drone 0.7 the signed yaml verification is deprecated, so we shouldn't need to check for it when using IAM roles.